### PR TITLE
[Smartswitch][pcied] Fix pcied handling for smartswitch during DPU detach

### DIFF
--- a/sonic-pcied/scripts/pcied
+++ b/sonic-pcied/scripts/pcied
@@ -107,10 +107,6 @@ class DaemonPcied(daemon_base.DaemonBase):
             stable_keys = self.status_table.getKeys()
             for stk in stable_keys:
                 self.status_table._del(stk)
-        if self.detach_info:
-            detach_info_keys = self.detach_info.getKeys()
-            for dk in detach_info_keys:
-                self.detach_info._del(dk)
 
     # load aer-fields into statedb
     def update_aer_to_statedb(self):
@@ -175,8 +171,10 @@ class DaemonPcied(daemon_base.DaemonBase):
         for key in detach_info_keys:
             dpu_info = self.detach_info.get(key)
             if dpu_info:
-                bus_info = dpu_info.get(PCIE_DETACH_BUS_INFO_FIELD)
-                dpu_state = dpu_info.get(PCIE_DETACH_DPU_STATE_FIELD)
+                # Convert tuple of field-value pairs to dictionary for easier access
+                dpu_dict = dict(dpu_info[1])
+                bus_info = dpu_dict.get(PCIE_DETACH_BUS_INFO_FIELD)
+                dpu_state = dpu_dict.get(PCIE_DETACH_DPU_STATE_FIELD)
                 if bus_info == pcie_dev and dpu_state == "detaching":
                     return True
 

--- a/sonic-pcied/tests/test_DaemonPcied.py
+++ b/sonic-pcied/tests/test_DaemonPcied.py
@@ -170,7 +170,6 @@ class TestDaemonPcied(object):
 
         daemon_pcied.device_table.getKeys.return_value = ['device1', 'device2']
         daemon_pcied.status_table.getKeys.return_value = ['status1']
-        daemon_pcied.detach_info.getKeys.return_value = ['detach1', 'detach2', 'detach3']
 
         daemon_pcied.__del__()
 
@@ -181,10 +180,6 @@ class TestDaemonPcied(object):
         assert daemon_pcied.status_table._del.call_count == 1
         daemon_pcied.status_table._del.assert_called_with('status1')
 
-        assert daemon_pcied.detach_info._del.call_count == 3
-        daemon_pcied.detach_info._del.assert_any_call('detach1')
-        daemon_pcied.detach_info._del.assert_any_call('detach2')
-        daemon_pcied.detach_info._del.assert_any_call('detach3')
 
     @mock.patch('pcied.load_platform_pcieutil', mock.MagicMock())
     @mock.patch('pcied.log.log_warning')

--- a/sonic-pcied/tests/test_DaemonPcied.py
+++ b/sonic-pcied/tests/test_DaemonPcied.py
@@ -148,11 +148,12 @@ class TestDaemonPcied(object):
         daemon_pcied = pcied.DaemonPcied(SYSLOG_IDENTIFIER)
         daemon_pcied.detach_info = mock.MagicMock()
         daemon_pcied.detach_info.getKeys = mock.MagicMock(return_value=['DPU_0', 'DPU_1'])
+        # Mock the get() method to return tuple of (exists, field_value_pairs)
         daemon_pcied.detach_info.get = mock.MagicMock(
             side_effect=lambda key: {
-                'DPU_0': {'bus_info': '0000:03:00.1', 'dpu_state': 'detaching'},
-                'DPU_1': {'bus_info': '0000:03:00.2', 'dpu_state': 'attached'}
-            }.get(key, None)
+                'DPU_0': (True, [('bus_info', '0000:03:00.1'), ('dpu_state', 'detaching')]),
+                'DPU_1': (True, [('bus_info', '0000:03:00.2'), ('dpu_state', 'attached')])
+            }.get(key, (False, []))
         )
 
         # Test when the device is in detaching mode


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Two changes are being done in this PR:
Remove deletion of the `PCIE_DETACH_INFO` from the pcied (This should be handled by the power off/power on of the DPU from the module_base implementation)
The returned value from `self.detach_info.get(key)` in pcied is of the form tuple:
`(True, [('bus_info', '0000:03:00.1'), ('dpu_state', 'detaching')])` This has to be handled correctly by the pcied (which was expecting a dictionary 




#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
