### PR TITLE
[Smartswitch] Use MODULE_ADMIN_DOWN when DPU operational state is offline

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -102,7 +102,6 @@ INVALID_IP = '0.0.0.0'
 CHASSIS_MODULE_ADMIN_STATUS = 'admin_status'
 MODULE_ADMIN_DOWN = 0
 MODULE_ADMIN_UP = 1
-MODULE_PRE_SHUTDOWN = 2
 MODULE_REBOOT_CAUSE_DIR = "/host/reboot-cause/module/"
 MAX_HISTORY_FILES = 10
 
@@ -1359,12 +1358,6 @@ class ChassisdDaemon(daemon_base.DaemonBase):
 
     def submit_dpu_callback(self, module_index, admin_state):
         module = self.module_updater.chassis.get_module(module_index)
-
-        # This is only valid on platforms which have pci_detach and sensord changes required. If it is not implemented,
-        # there are no actions taken during this function execution.
-        if admin_state == MODULE_PRE_SHUTDOWN:
-            try_get(module.module_pre_shutdown, default=False)
-        # Set admin_state change in progress using the centralized method
         if admin_state == MODULE_ADMIN_DOWN:
             try_get(module.set_admin_state_gracefully, admin_state, default=False)
 
@@ -1387,10 +1380,7 @@ class ChassisdDaemon(daemon_base.DaemonBase):
                 # Get admin state of DPU
                 admin_state = self.module_updater.get_module_admin_status(module_name)
                 if admin_state == ModuleBase.MODULE_STATUS_EMPTY:
-                    op = MODULE_PRE_SHUTDOWN
-                    if operational_state != ModuleBase.MODULE_STATUS_OFFLINE:
-                        # shutdown DPU
-                        op = MODULE_ADMIN_DOWN
+                    op = MODULE_ADMIN_DOWN
 
                 # Initialize DPU_STATE DB table on bootup
                 dpu_state_key = "DPU_STATE|" + module_name

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -1549,8 +1549,8 @@ def test_set_initial_dpu_admin_state_empty_offline():
         # Verify DPU state was updated with 'down' since operational state is OFFLINE
         mock_update_dpu_state.assert_called_once_with("DPU_STATE|DPU0", 'down')
 
-        # Verify callback was submitted with MODULE_PRE_SHUTDOWN since admin state is EMPTY and oper state is OFFLINE
-        mock_submit_callback.assert_called_once_with(0, MODULE_PRE_SHUTDOWN)
+        # Verify callback was submitted with MODULE_ADMIN_DOWN when admin state is EMPTY
+        mock_submit_callback.assert_called_once_with(0, MODULE_ADMIN_DOWN)
 
 
 def test_set_initial_dpu_admin_state_empty_not_offline():
@@ -1600,7 +1600,7 @@ def test_set_initial_dpu_admin_state_empty_not_offline():
         # Verify DPU state was updated with 'down' since operational state is not ONLINE
         mock_update_dpu_state.assert_called_once_with("DPU_STATE|DPU0", 'down')
 
-        # Verify callback was submitted with MODULE_ADMIN_DOWN since admin state is EMPTY and oper state is not OFFLINE
+        # Verify callback was submitted with MODULE_ADMIN_DOWN when admin state is EMPTY
         mock_submit_callback.assert_called_once_with(0, MODULE_ADMIN_DOWN)
 
 
@@ -2041,25 +2041,10 @@ def test_submit_dpu_callback():
     daemon_chassisd.module_updater = module_updater
     module_updater.module_table.get = MagicMock(return_value=(True, []))
 
-    # Test MODULE_ADMIN_DOWN scenario
-    with patch.object(module, 'module_pre_shutdown') as mock_pre_shutdown, \
-         patch.object(module, 'set_admin_state_gracefully') as mock_set_admin_state_gracefully:
+    # Test MODULE_ADMIN_DOWN scenario - set_admin_state_gracefully is called
+    with patch.object(module, 'set_admin_state_gracefully') as mock_set_admin_state_gracefully:
         daemon_chassisd.submit_dpu_callback(index, MODULE_ADMIN_DOWN)
-        # Verify pre_shutdown is not called for admin down
-        mock_pre_shutdown.assert_not_called()
-        # Verify set_admin_state_gracefully is called with MODULE_ADMIN_DOWN
         mock_set_admin_state_gracefully.assert_called_once_with(MODULE_ADMIN_DOWN)
-
-    # Test MODULE_PRE_SHUTDOWN scenario
-    with patch.object(module, 'module_pre_shutdown') as mock_pre_shutdown, \
-         patch.object(module, 'set_admin_state_gracefully') as mock_set_admin_state_gracefully:
-
-        module_updater.module_table.get = MagicMock(return_value=(True, []))
-        daemon_chassisd.submit_dpu_callback(index, MODULE_PRE_SHUTDOWN)
-
-        # Verify only pre_shutdown is called for pre-shutdown state
-        mock_pre_shutdown.assert_called_once()
-        mock_set_admin_state_gracefully.assert_not_called()
 
 def test_chassis_daemon_assertion():
     chassis = MockChassis()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
- Remove `MODULE_PRE_SHUTDOWN` constant and all related handling from chassisd.
- When DPU admin state is `MODULE_STATUS_EMPTY`, always submit `MODULE_ADMIN_DOWN` to the callback (no longer use `MODULE_PRE_SHUTDOWN` when operational state is offline).
- Simplify `submit_dpu_callback`: it no longer invokes `module_pre_shutdown`; it only calls `set_admin_state_gracefully` when admin state is `MODULE_ADMIN_DOWN`.
- Update unit tests to match: expect `MODULE_ADMIN_DOWN` for the empty-offline case, and remove tests for `MODULE_PRE_SHUTDOWN`.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
The DPU can be in an intermediate state where `operational_state` is offline but we still need to force power off the DPU. Previously, when admin state was EMPTY and operational state was OFFLINE, the daemon used `MODULE_PRE_SHUTDOWN`, which did not reliably power off the DPU in this case. By always using `MODULE_ADMIN_DOWN` when admin state is EMPTY (regardless of operational state), we ensure the DPU is forced power off when required.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
- Updated and ran unit tests in `sonic-chassisd/tests/test_chassisd.py`:
  - `test_set_initial_dpu_admin_state_empty_offline`: now expects `MODULE_ADMIN_DOWN` instead of `MODULE_PRE_SHUTDOWN`.
  - `test_set_initial_dpu_admin_state_empty_not_offline`: assertion/comment aligned with new behavior.
  - `test_submit_dpu_callback`: removed `MODULE_PRE_SHUTDOWN` scenario; retained `MODULE_ADMIN_DOWN` test.

#### Additional Information (Optional)
